### PR TITLE
bugfix: for some images gm identify -format %[exif:orientation] returns ...

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -94,7 +94,7 @@ class Engine(EngineBase):
             args.extend(['-format', '%[exif:orientation]', image['source']])
             p = Popen(args, stdout=PIPE)
             p.wait()
-            result = p.stdout.read().strip()
+            result = p.stdout.read().strip().split('\n')[0]
             if result and result != 'unknown':
                 result = int(result)
                 options = image['options']


### PR DESCRIPTION
...more than one line, e.g. '0\n0'. With this change we take only the first result. Currently exception is thrown. ValueError: invalid literal for int() with base 10: '0\\n0'

Related to #233