### PR TITLE
is_portrait failing for EXIF tag based portrait images.

### DIFF
--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -42,6 +42,12 @@ class EngineBase(object):
             return self._orientation(image)
         return image
 
+    def flip_dimensions(self, image, geometry=None, options=None):
+        options = options or {}
+        if options.get('orientation', settings.THUMBNAIL_ORIENTATION):
+            return self._flip_dimensions(image)
+        return False
+
     def colorspace(self, image, geometry, options):
         """
         Wrapper for ``_colorspace``

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -40,11 +40,13 @@ class EngineBase(object):
         """
         if options.get('orientation', settings.THUMBNAIL_ORIENTATION):
             return self._orientation(image)
+        self.reoriented = True
         return image
 
     def flip_dimensions(self, image, geometry=None, options=None):
         options = options or {}
-        if options.get('orientation', settings.THUMBNAIL_ORIENTATION):
+        reoriented = hasattr(self, 'reoriented')
+        if options.get('orientation', settings.THUMBNAIL_ORIENTATION) and not reoriented:
             return self._flip_dimensions(image)
         return False
 

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -133,6 +133,17 @@ class Engine(EngineBase):
             image['options']['auto-orient'] = None
         return image
 
+    def _flip_dimensions(self, image):
+        if settings.THUMBNAIL_CONVERT.endswith('gm convert'):
+            args = settings.THUMBNAIL_IDENTIFY.split()
+            args.extend(['-format', '%[exif:orientation]', image['source']])
+            p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p.wait()
+            result = p.stdout.read().strip()
+            return result != 'unknown' and int(result) in [5, 6, 7, 8]
+        else:
+            return False
+
     def _colorspace(self, image, colorspace):
         """
         `Valid colorspaces

--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -54,6 +54,14 @@ class Engine(EngineBase):
 
         return image
 
+    def flip_dimensions(self, image):
+        return image.orientation() in [
+            OrientationType.LeftTopOrientation,
+            OrientationType.RightTopOrientation,
+            OrientationType.RightBottomOrientation,
+            OrientationType.LeftBottomOrientation,
+        ]
+
     def _colorspace(self, image, colorspace):
         if colorspace == 'RGB':
             image.type(ImageType.TrueColorMatteType)

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -87,6 +87,17 @@ class Engine(EngineBase):
 
         return image
 
+    def _flip_dimensions(self, image):
+        try:
+            exif = image._getexif()
+        except (AttributeError, IOError, KeyError, IndexError):
+            exif = None
+
+        if exif:
+            orientation = exif.get(0x0112)
+
+        return orientation in [5, 6, 7, 8]
+
     def _colorspace(self, image, colorspace):
         if colorspace == 'RGB':
             if image.mode == 'RGBA':

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -95,8 +95,9 @@ class Engine(EngineBase):
 
         if exif:
             orientation = exif.get(0x0112)
+            return orientation in [5, 6, 7, 8]
 
-        return orientation in [5, 6, 7, 8]
+        return False
 
     def _colorspace(self, image, colorspace):
         if colorspace == 'RGB':

--- a/sorl/thumbnail/engines/wand_engine.py
+++ b/sorl/thumbnail/engines/wand_engine.py
@@ -47,6 +47,9 @@ class Engine(EngineBase):
         image.orientation = 'top_left'
         return image
 
+    def _flip_dimensions(self, image):
+        return image.orientation in ['left_top', 'right_top', 'right_bottom', 'left_bottom']
+
     def _colorspace(self, image, colorspace):
         if colorspace == 'RGB':
             image.type = 'truecolor'

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -117,7 +117,17 @@ class ImageFile(BaseImageFile):
             # This is the worst case scenario
             image = default.engine.get_image(self)
             size = default.engine.get_image_size(image)
+            if self.flip_dimensions(image):
+                size = list(size)
+                size.reverse()
         self._size = list(size)
+
+    def flip_dimensions(self, image):
+        """
+        Do not manipulate image, but ask engine whether we'd be doing a 90deg
+        rotation at some point.
+        """
+        return default.engine.flip_dimensions(image)
 
     @property
     def size(self):


### PR DESCRIPTION
Really sorry I didn't have time to write any tests! Here's the image that was screwing things up for me.

Essentially the issue is whilst doing a thumbnail caused engine._orientation to be called, which does the flip, this was not done on the original image (and thus the |is_portrait filter is incorrect). Doing _orientation on the original image is wasteful and silly, so what I've done is take the logic from orientation that decides whether to rotate +/- 90deg and popped it in another function, _flip_dimensions. This is then called when get_image_size is done.

Here's an image that fails:

http://files.blit.cc/DSC01135_2.JPG
