### PR TITLE
Improve Cropping Behavior #166 by Sethdenner 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,17 @@ matrix:
     - python: "2.7"
       env:
         - DJANGO_VERSION=">=1.4,<1.5" SETTINGS=pgmagick APT='libgraphicsmagick++-dev libboost-python-dev libboost-thread-dev'
-        - WHEEL=pgmagick-0.5.7-cp27-none-linux_x86_64.whl
+        - PIP=pgmagick
 
     - python: "2.7"
       env:
         - DJANGO_VERSION=">=1.5,<1.6" SETTINGS=pgmagick APT='libgraphicsmagick++-dev libboost-python-dev libboost-thread-dev'
-        - WHEEL=pgmagick-0.5.7-cp27-none-linux_x86_64.whl
+        - PIP=pgmagick
 
     - python: "2.7"
       env:
         - DJANGO_VERSION=">=1.6,<1.7" SETTINGS=pgmagick APT='libgraphicsmagick++-dev libboost-python-dev libboost-thread-dev'
-        - WHEEL=pgmagick-0.5.7-cp27-none-linux_x86_64.whl
+        - PIP=pgmagick
 
 before_install:
   - sudo apt-get update -qq
@@ -69,8 +69,7 @@ after_success:
 install:
   - pip install -U pip
   - pip install -q coveralls
-  - pip install -q Pillow
-  - pip install -q $PIP
+  - pip install -q Pillow $PIP
   - pip install -q Django$DJANGO_VERSION
 
 script:

--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -28,6 +28,9 @@ def toint(number):
         if number > 1:
             number = round(number, 0)
         else:
+            # The following solves when image has small dimensions (like 1x54)
+            # then scale factor 1 * 0.296296 and `number` will store `0`
+            # that will later raise ZeroDivisionError.
             number = round(math.ceil(number), 0)
     return int(number)
 


### PR DESCRIPTION
This is an upgrades the Original feature in #166 with the current development branch

> sorl-thumbnail has been a great asset in our Django based web project however the implementation of cropping left a little to be desired (or at least the implementation didn't make a lot of sense to me) so I made some modifications.
> I modified the cropping behavior in the following ways:
> The crop parameter now takes x,y coordinates of the top left corner as well as width/height of the crop region.
> Cropping occurs before scalling.
> Feel free to merge this into the main project if you also feel that this is an improvement. If you have any additional notes I will be happy to make further modifications if this isn't exactly what you had in mind.

https://github.com/mariocesar/sorl-thumbnail/pull/166
