### PR TITLE
Wrap import_module into a try/except clause

### DIFF
--- a/sorl/thumbnail/compat.py
+++ b/sorl/thumbnail/compat.py
@@ -32,6 +32,12 @@ try:
 except ImportError:
     from django.utils.encoding import smart_unicode as smart_text
 
+try:
+    # Python >= 2.7
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 # Python 2 and 3
 
 if PY3:

--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
-import math
+
 import hashlib
+import math
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
-
-from sorl.thumbnail.compat import json, encode, smart_text
+from sorl.thumbnail.compat import encode, json, smart_text, import_module
 
 
 class ThumbnailError(Exception):


### PR DESCRIPTION
Django provided `django.utils.importlib` as a shim for stdlib's `importlib` for python versions < 2.7. In Django 1.8 that shim will generate a warning, and in Django 1.9 will be removed. So I wrapped that import into try/except clause + applied `isort` on helpers.py