### PR TITLE
Fix convert_engine under Windows

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -51,6 +51,7 @@ class Engine(EngineBase):
 
         if os.name == 'nt':
             os_handle, file_path = tempfile.mkstemp(suffix=suffix)
+            os.close(os_handle)
 
             args.append(file_path)
             args = map(smart_str, args)

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -64,6 +64,8 @@ class Engine(EngineBase):
 
             with open(file_path, 'rb') as fp:
                 thumbnail.write(fp.read())
+
+            os.remove(file_path)
         else:
             with NamedTemporaryFile(suffix=suffix, mode='rb') as fp:
                 args.append(fp.name)

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -108,13 +108,28 @@ class Engine(EngineBase):
         This is not very good for imagemagick because it will say anything is
         valid that it can use as input.
         """
-        with NamedTemporaryFile(mode='wb') as fp:
-            fp.write(raw_data)
-            fp.flush()
+        if os.name == 'nt':
+            os_handle, file_path = tempfile.mkstemp()
+            os.close(os_handle)
+
+            with open(file_path, 'wb') as fp:
+                fp.write(raw_data)
+                fp.flush()
+
             args = settings.THUMBNAIL_IDENTIFY.split(' ')
             args.append(fp.name)
             p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             retcode = p.wait()
+
+            os.remove(file_path)
+        else:
+            with NamedTemporaryFile(mode='wb') as fp:
+                fp.write(raw_data)
+                fp.flush()
+                args = settings.THUMBNAIL_IDENTIFY.split(' ')
+                args.append(fp.name)
+                p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                retcode = p.wait()
         return retcode == 0
 
     def _orientation(self, image):


### PR DESCRIPTION
According to
https://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile
it is not possible under Windows that a temporary file, which is opened
by the python process via NamedTemporaryFile, is used by another process
at the same time. Therefore starting the subprocess inside the with
NamedTemporaryFile block fails because the started process can not
access the created temporary file. The usage of tempfile.mkstemp allows
that the temporary file is not opened when the subprocess is started.