### PR TITLE
Fix warning Django 1.9

### DIFF
--- a/sorl/thumbnail/compat.py
+++ b/sorl/thumbnail/compat.py
@@ -36,7 +36,8 @@ try:
     # Python >= 2.7
     from importlib import import_module
 except ImportError:
-    from django.utils.importlib import import_module
+    if django.VERSION < (1, 8):
+        from django.utils.importlib import import_module
 
 # Python 2 and 3
 


### PR DESCRIPTION
Fix deprecated warning for django.utils.importlib in django 1.9