### PR TITLE
Fix warning Django 1.9

### DIFF
--- a/sorl/thumbnail/kvstores/cached_db_kvstore.py
+++ b/sorl/thumbnail/kvstores/cached_db_kvstore.py
@@ -1,4 +1,10 @@
-from django.core.cache import cache, get_cache, InvalidCacheBackendError
+from django.core.cache import cache, InvalidCacheBackendError
+
+try:
+    from django.core.cache import caches
+except:
+    from django.core.cache import get_cache as caches
+
 from sorl.thumbnail.kvstores.base import KVStoreBase
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.models import KVStore as KVStoreModel
@@ -12,7 +18,7 @@ class KVStore(KVStoreBase):
     def __init__(self):
         super(KVStore, self).__init__()
         try:
-            self.cache = get_cache(settings.THUMBNAIL_CACHE)
+            self.cache = hasattr(caches, 'call') and caches(settings.THUMBNAIL_CACHE) or caches[settings.THUMBNAIL_CACHE]
         except InvalidCacheBackendError:
             self.cache = cache
 


### PR DESCRIPTION
Fix this warning:
```
[29/Apr/2015 23:04:39]"GET /chaining/filter/tags/Subtopic/topic/10/ HTTP/1.1" 200 43
/home/tulipan/Proyectos/TiempoTurco/lib/python3.4/site-packages/sorl/thumbnail/kvstores/cached_db_kvstore.py:15: RemovedInDjango19Warning: 'get_cache' is deprecated in favor of 'caches'.
  self.cache = get_cache(settings.THUMBNAIL_CACHE)
```

Please see here: https://github.com/jieter/django-ratelimit/commit/47e6cb1e660b9ed7065fcd9f367c3323665ac684