### PR TITLE
Fix comparing bytes and str in Python 3

### DIFF
--- a/sorl/thumbnail/compat.py
+++ b/sorl/thumbnail/compat.py
@@ -52,6 +52,9 @@ if PY3:
     text_type = str
     string_type = str
 
+    def b(s):
+        return s.encode("latin-1")
+
     def encode(value, charset='utf-8', errors='ignore'):
         if isinstance(value, bytes):
             return value
@@ -72,6 +75,9 @@ elif PY2:
     text_type = unicode
     string_type = basestring
     urlsplit = urlparse.urlsplit
+
+    def b(s):
+        return s
 
     def encode(value, charset='utf-8', errors='ignore'):
         if isinstance(value, unicode):

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -8,6 +8,7 @@ from django.utils.datastructures import SortedDict
 from django.utils.encoding import smart_str
 
 from sorl.thumbnail.base import EXTENSIONS
+from sorl.thumbnail.compat import b
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.engines.base import EngineBase
 
@@ -108,7 +109,7 @@ class Engine(EngineBase):
             p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             p.wait()
             result = p.stdout.read().strip()
-            if result and result != 'unknown':
+            if result and result != b('unknown'):
                 result = int(result)
                 options = image['options']
                 if result == 2:


### PR DESCRIPTION
This problem occurs when running in Python 3 and using GraphicsMagick engine.
In Python 3, a type of `result` is `bytes` but a type of `'unknown'` is `str`.

To support Python 2.5, we cannot use byte literals.
`b()` in compat.py is also defined in six (http://pythonhosted.org/six/#six.b).