### PR TITLE
Full Django 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ env:
   - TOX_ENV=py27-django17-wand
   - TOX_ENV=py27-django17-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
   - TOX_ENV=py27-django17-dbm
+  - TOX_ENV=py27-django18-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
+  - TOX_ENV=py27-django18-imagemagick APT=imagemagick
+  - TOX_ENV=py27-django18-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py27-django18-redis
+  - TOX_ENV=py27-django18-wand
+  - TOX_ENV=py27-django18-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
+  - TOX_ENV=py27-django18-dbm
   - TOX_ENV=py34-django15-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
   - TOX_ENV=py34-django15-imagemagick APT=imagemagick
   - TOX_ENV=py34-django15-graphicsmagick APT=graphicsmagick
@@ -50,6 +57,12 @@ env:
   - TOX_ENV=py34-django17-redis
   - TOX_ENV=py34-django17-wand
   - TOX_ENV=py34-django17-dbm
+  - TOX_ENV=py34-django18-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
+  - TOX_ENV=py34-django18-imagemagick APT=imagemagick
+  - TOX_ENV=py34-django18-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py34-django18-redis
+  - TOX_ENV=py34-django18-wand
+  - TOX_ENV=py34-django18-dbm
 
 before_install:
   - sudo apt-get update -qq

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Thumbnails for Django.
 Features at a glance
 ====================
 
-- Support for Django 1.4, 1.5, 1.6 and 1.7
-- Python 3 support (for Django 1.5, 1.6, 1.7)
+- Support for Django 1.4, 1.5, 1.6, 1.7 and 1.8
+- Python 3 support (for Django 1.5, 1.6, 1.7, 1.8)
 - Storage support
 - Pluggable Engine support for `Pillow`_, `ImageMagick`_, `PIL`_, `Wand`_ and `pgmagick`_
 - Pluggable Key Value Store support (cached db, redis)

--- a/sorl/thumbnail/compat.py
+++ b/sorl/thumbnail/compat.py
@@ -38,6 +38,19 @@ try:
 except ImportError:
     from django.utils.importlib import import_module
 
+if django.VERSION >= (1, 7):
+    from django.core.cache import caches
+    def get_cache(name):
+        return caches[name]
+else:
+    from django.core.cache import get_cache
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
+
+
 # Python 2 and 3
 
 if PY3:

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -4,12 +4,12 @@ import os
 import subprocess
 from tempfile import NamedTemporaryFile
 
-from django.utils.datastructures import SortedDict
 from django.utils.encoding import smart_str
 
 from sorl.thumbnail.base import EXTENSIONS
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.engines.base import EngineBase
+from sorl.thumbnail.compat import OrderedDict
 
 
 size_re = re.compile(r'^(?:.+) (?:[A-Z]+) (?P<x>\d+)x(?P<y>\d+)')
@@ -69,7 +69,7 @@ class Engine(EngineBase):
         """
         with NamedTemporaryFile(mode='wb', delete=False) as fp:
             fp.write(source.read())
-        return {'source': fp.name, 'options': SortedDict(), 'size': None}
+        return {'source': fp.name, 'options': OrderedDict(), 'size': None}
 
     def get_image_size(self, image):
         """

--- a/sorl/thumbnail/kvstores/cached_db_kvstore.py
+++ b/sorl/thumbnail/kvstores/cached_db_kvstore.py
@@ -1,4 +1,3 @@
-import django
 from django.core.cache import cache, InvalidCacheBackendError
 
 from sorl.thumbnail.kvstores.base import KVStoreBase

--- a/sorl/thumbnail/kvstores/cached_db_kvstore.py
+++ b/sorl/thumbnail/kvstores/cached_db_kvstore.py
@@ -5,6 +5,7 @@ from sorl.thumbnail.conf import settings
 from sorl.thumbnail.models import KVStore as KVStoreModel
 from sorl.thumbnail.compat import get_cache
 
+
 class EMPTY_VALUE(object):
     pass
 

--- a/sorl/thumbnail/kvstores/cached_db_kvstore.py
+++ b/sorl/thumbnail/kvstores/cached_db_kvstore.py
@@ -1,8 +1,10 @@
-from django.core.cache import cache, get_cache, InvalidCacheBackendError
+import django
+from django.core.cache import cache, InvalidCacheBackendError
+
 from sorl.thumbnail.kvstores.base import KVStoreBase
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.models import KVStore as KVStoreModel
-
+from sorl.thumbnail.compat import get_cache
 
 class EMPTY_VALUE(object):
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ django_find_project = false
 skipsdist = True
 envlist =
     {py27}-django14-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm},
-    {py27,py34}-django{15,16,17}-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm}
+    {py27,py34}-django{15,16,17,18}-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -26,6 +26,7 @@ deps =
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
 
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}


### PR DESCRIPTION
 - Move get_cache, OrderedDict to sorl.thumbnail.compat
 - Add Django 1.8 to tox configuration

Tests pass (at least with the same consistency they do prior to the changes).

Collects and fixes #360, #362, #363, #364, #367.