### PR TITLE
Limit tox to test_*.py files; report warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ max-line-length=100
 exclude=.tox,docs,tests/settings,sorl/thumbnail/__init__.py,sorl/thumbnail/admin/__init__.py,sorl/thumbnail/compat.py,tests/thumbnail_tests/compat.py
 
 [pytest]
-python_files = *.py
+python_files = test_*.py
 django_find_project = false
 
 [tox]
@@ -37,4 +37,4 @@ setenv =
     pgmagick: DJANGO_SETTINGS_MODULE=tests.settings.pgmagick
     dbm: DJANGO_SETTINGS_MODULE=tests.settings.dbm
 
-commands = py.test --cov-config .coveragerc --cov sorl
+commands = py.test -rw --cov-config .coveragerc --cov sorl


### PR DESCRIPTION
Tox was issuing warnings because of support classes within the test
directory that are named with "Test*" patterns, but are not TestCase
subclasses (``kvstore.TestKVStore`` and ``storage.TestStorage``).

Fix this by limiting test discovery to files that match the
``test_*.py`` pattern. Also, add the "-rw" switch to the py.test
invocation to spell out warnings rather than just counting them.