### PR TITLE
Fix default_storage to be from thumbnail.defaults and not from django

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -5,7 +5,7 @@ import os
 import re
 
 from django.core.files.base import File, ContentFile
-from django.core.files.storage import Storage#, default_storage
+from django.core.files.storage import Storage  # , default_storage
 from django.utils.functional import LazyObject, empty
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -5,13 +5,14 @@ import os
 import re
 
 from django.core.files.base import File, ContentFile
-from django.core.files.storage import Storage, default_storage
+from django.core.files.storage import Storage#, default_storage
 from django.utils.functional import LazyObject, empty
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.compat import (json, urlopen, urlparse, urlsplit,
                                    quote, quote_plus,
                                    URLError, force_unicode, encode)
+from sorl.thumbnail.default import storage as default_storage
 from sorl.thumbnail.helpers import ThumbnailError, tokey, get_module_class, deserialize
 from sorl.thumbnail.parsers import parse_geometry
 

--- a/sorl/thumbnail/migrations/0001_initial.py
+++ b/sorl/thumbnail/migrations/0001_initial.py
@@ -13,7 +13,10 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='KVStore',
             fields=[
-                ('key', models.CharField(serialize=False, db_column='key', max_length=200, primary_key=True)),
+                ('key', models.CharField(serialize=False,
+                                         db_column='key',
+                                         max_length=200,
+                                         primary_key=True)),
                 ('value', models.TextField()),
             ],
         ),


### PR DESCRIPTION
This is because we won't use THUMBNAIL_STORAGE setting here -- OK, by default
it is DEFAULT_FILE_STORAGE, but if we change it, we want to use
THUMBNAIL_STORAGE everywhere.