### PR TITLE
KVStore cache backend needs to be unique per thread

### DIFF
--- a/sorl/thumbnail/kvstores/cached_db_kvstore.py
+++ b/sorl/thumbnail/kvstores/cached_db_kvstore.py
@@ -12,10 +12,14 @@ class EMPTY_VALUE(object):
 class KVStore(KVStoreBase):
     def __init__(self):
         super(KVStore, self).__init__()
+
+    @property
+    def cache(self):
         try:
-            self.cache = get_cache(settings.THUMBNAIL_CACHE)
+            kv_cache = get_cache(settings.THUMBNAIL_CACHE)
         except InvalidCacheBackendError:
-            self.cache = cache
+            kv_cache = cache
+        return kv_cache
 
     def clear(self, delete_thumbnails=False):
         """

--- a/tests/thumbnail_tests/test_kvstore.py
+++ b/tests/thumbnail_tests/test_kvstore.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+import threading
+import unittest
+
+from sorl.thumbnail.kvstores.cached_db_kvstore import KVStore
+
+
+class KVStoreTestCase(unittest.TestCase):
+    @unittest.skipIf(threading is None, 'Test requires threading')
+    def test_cache_backend(self):
+        kv = KVStore()
+        cache_backends = []
+
+        def thread_cache_backend():
+            cache_backends.append(kv.cache)
+
+        for x in range(2):
+            t = threading.Thread(target=thread_cache_backend)
+            t.start()
+            t.join()
+
+        # Cache backend for each thread needs to be unique
+        self.assertNotEqual(cache_backends[0], cache_backends[1])


### PR DESCRIPTION
Using the default key value store with pylibmc currently causes HTTP 502 errors if multiple requests are being processed by the same process under different threads.

[pylibmc isn't thread safe](http://sendapatch.se/projects/pylibmc/misc.html#threading), and Django supports this by returning a [different cache backend for each thread](https://github.com/django/django/blob/927b30a6ab33ea33e5e3b1e7408ac1d5d267ff6a/docs/topics/cache.txt#L727). However sorl-thumbnail only checks the KVStore cache backend once due to https://github.com/mariocesar/sorl-thumbnail/blob/master/sorl/thumbnail/default.py#L28.

This patch ensures that a different cache backend is used per thread as Django intends it to be used.