### PR TITLE
PNG transparency not preserved with Wand

### DIFF
--- a/sorl/thumbnail/engines/wand_engine.py
+++ b/sorl/thumbnail/engines/wand_engine.py
@@ -50,9 +50,15 @@ class Engine(EngineBase):
 
     def _colorspace(self, image, colorspace):
         if colorspace == 'RGB':
-            image.type = 'truecolor'
+            if image.alpha_channel:
+                image.type = 'truecolormatte'
+            else:
+                image.type = 'truecolor'
         elif colorspace == 'GRAY':
-            image.type = 'grayscale'
+            if image.alpha_channel:
+                image.type = 'grayscalematte'
+            else:
+                image.type = 'grayscale'
         else:
             return image
         return image

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -176,6 +176,13 @@ class SimpleTestCase(BaseTestCase):
         output = p2.communicate()[0].strip()
         self.assertEqual(output.decode('utf-8'), '1')
 
+    def test_transparency(self):
+        item, _created = self.create_image(
+            '50x50_transparent.png', (50, 50), transparent=True)
+        th = self.BACKEND.get_thumbnail(item.image, '11x11', format='PNG')
+        img = Image.open(th.storage.path(th.name))
+        self.assertTrue(self.is_transparent(img))
+
     def test_image_file_deserialize(self):
         im = ImageFile(Item.objects.get(image='500x500.jpg').image)
         default.kvstore.set(im)


### PR DESCRIPTION
When using the the Wand engine, generated thumbnails of PNG images with transparency no longer have any transparency. I am using sorl-thumbnail 11.12.1b and Wand 0.3.8.

My only thumbnail related settings are:

    THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.wand_engine.Engine'
    THUMBNAIL_QUALITY = 90
    THUMBNAIL_ORIENTATION = False
    THUMBNAIL_PRESERVE_FORMAT = True

If I comment out the `THUMBNAIL_ENGINE` setting to return to sorl-thumbnail's default of PIL, the generated thumbnails are fine. The problem is specific to Wand. (I'm not sure if this is related to #298 since he claims to be using the default engine.)

Any ideas where I should start looking?