### PR TITLE
PNG files haven't transparency.

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -99,7 +99,7 @@ class Engine(EngineBase):
             if image.mode == 'LA' or (image.mode == 'P' and 'transparency' in image.info):
                 newimage = image.convert('RGBA')
                 transparency = image.info.get('transparency')
-                if transparency:
+                if transparency is not None:
                     mask = Image.new('L', image.size, color=transparency)
                     newimage.putalpha(mask)
                 return newimage

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -97,7 +97,12 @@ class Engine(EngineBase):
             if image.mode == 'RGBA':
                 return image  # RGBA is just RGB + Alpha
             if image.mode == 'LA' or (image.mode == 'P' and 'transparency' in image.info):
-                return image.convert('RGBA')
+                newimage = image.convert('RGBA')
+                transparency = image.info.get('transparency')
+                if transparency:
+                    mask = Image.new('L', image.size, color=transparency)
+                    newimage.putalpha(mask)
+                return newimage
             return image.convert('RGB')
         if colorspace == 'GRAY':
             return image.convert('L')


### PR DESCRIPTION
Hi, how are you?

Here have a new issue, i think.

My png file haven't background color, have transparency, and, when i upload using sorl-thumbnail's ImageField the image have black background color, see:

![sorl-thumbnailissue](https://cloud.githubusercontent.com/assets/5034215/4128710/c29d727c-3310-11e4-951a-d7dff477ec88.png)

How can we fix this bug?