### PR TITLE
Getting EXIF data errors

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -69,7 +69,7 @@ class Engine(EngineBase):
     def _orientation(self, image):
         try:
             exif = image._getexif()
-        except (AttributeError, IOError, KeyError, IndexError):
+        except:
             exif = None
 
         if exif:


### PR DESCRIPTION
Corresponding issue on Pillow repository: https://github.com/python-pillow/Pillow/issues/1359

In https://github.com/mariocesar/sorl-thumbnail/blob/master/sorl/thumbnail/engines/pil_engine.py#L70 the exif data is retrieved, however this often goes wrong (now 4 exception types are caught) and I'm getting TypeError with exif data from Photoshop it seems.

I suggest changing the `except` line to a blanket `except Exception`, similarly to how easy-thumbnails changed this. There are too many different possible exceptions to catch.