### PR TITLE
Add a vipsthumbnail engine

### DIFF
--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,5 +1,8 @@
 [run]
 source = sorl
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
 
 omit =
     */sorl-thumbnail/sorl/__init__.py

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ changedir = {toxinidir}/tests
 deps =
     pytest
     pytest-cov
+    coverage <= 3.7.1
     pytest-django
     Pillow
     redis: redis


### PR DESCRIPTION
Add another engine, this time for `vipsthumbnail`. This is an experimental hack and not production-ready code.

## Motivation

`vipsthumbbnail` can thumbnail large images quickly and using little memory. For example, for a 10,000 x 10,000 pixel RGB image:

```
$ time convert wtc.png -resize 128x128 x.jpg
real	0m5.604s
user	0m7.012s
sys	0m0.384s
peak RES: 600mb

$ time vipsthumbnail wtc.png --size 128x128 -o x.jpg
real	0m3.530s
user	0m3.508s
sys	0m0.016s
peak RES: 60mb
```

For jpg, `vipsthumbnail` uses shrink-on-load, so the speed difference is larger. `convert` would be much quicker with `-define hints`, but I'm not sure sorl-thumbnail uses them. Did I miss them in the code?

```
$ time convert wtc.jpg -resize 128x128 x.jpg
real	0m2.833s
user	0m4.308s
sys	0m0.320s
peak RES: 600mb

$ time vipsthumbnail wtc.jpg --size 128x128 -o x.jpg
real	0m0.297s
user	0m0.284s
sys	0m0.012s
peak RES: 10mb
```

See also:

http://www.vips.ecs.soton.ac.uk/index.php?title=Speed_and_Memory_Use

## What's missing?

This fails 12 tests, mostly due to a missing `_crop()` method. I'm not sure what to do about this, vipsthumbnail has a `--crop` option, but it crops to the dimensions given in `--size`, you can't specify a different crop box.

That's running against git master vips. If you install `vips-tools` from apt, you'll see more failures than that. 

`vipsthumbnail` has some options for colour management which are not expoosed. You can give an output profile and a fallback input profile. I'm not sure how to handle this.

`vipsthumbnail` has an auto-rotate option, but it only supports the basic four rotates, it doesn't do the flips. This causes another couple of tests to fail.

`vipsthumbnail` does not support conversion to greyscale.

`libvips` has a Python binding and it would be pretty easy to make a sorl engine which used that. This would be a fair bit quicker, and it would be easy to support the missing features. It would also avoid the
write-to-file / read-from-file steps.