### PR TITLE
Add support for |resolution filter when DUMMY mode is enabled.

### DIFF
--- a/tests/thumbnail_tests/templates/thumbnaild4.html
+++ b/tests/thumbnail_tests/templates/thumbnaild4.html
@@ -1,0 +1,5 @@
+{% load thumbnail %}{% spaceless %}
+{% thumbnail "" "x400" as im %}
+<img src="{{ im.url }}" width="{{ im.x }}" height="{{ im.y }}" srcset="{{ im.url|resolution:'2x' }} 2x; {{ im.url|resolution:'1.5x' }} 1.5x">
+{% endthumbnail %}
+{% endspaceless %}

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -349,6 +349,10 @@ class DummyTestCase(unittest.TestCase):
     def setUp(self):
         self.BACKEND = get_module_class(settings.THUMBNAIL_BACKEND)()
 
+    def tearDown(self):
+        super(DummyTestCase, self).tearDown()
+        settings.THUMBNAIL_ALTERNATIVE_RESOLUTIONS = []
+
     def test_dummy_tags(self):
         settings.THUMBNAIL_DUMMY = True
 
@@ -363,6 +367,12 @@ class DummyTestCase(unittest.TestCase):
         self.assertEqual(val, '<img src="http://dummyimage.com/600x400" width="600" height="400">')
 
         settings.THUMBNAIL_DUMMY = False
+
+    def test_alternative_resolutions(self):
+        settings.THUMBNAIL_DUMMY = True
+        settings.THUMBNAIL_ALTERNATIVE_RESOLUTIONS = [1.5, 2]
+        val = render_to_string('thumbnaild4.html', {}).strip()
+        self.assertEqual(val, '<img src="http://dummyimage.com/600x400" width="600" height="400" srcset="http://dummyimage.com/1200x800 2x; http://dummyimage.com/900x600 1.5x">')
 
 
 class ImageValidationTestCase(unittest.TestCase):


### PR DESCRIPTION
Further to ticket #400:

Modify the resolution filter to recognise image URLs that match the DUMMY_SOURCE pattern when DUMMY is enabled, extract the original dimensions, multiply by the resolution requested, then re-generate a dummy request. This fixes problems with dummy source providers that don't support @2x notation, i.e. all of them.