### PR TITLE
Added a backend for dynamodb (AWS)

### DIFF
--- a/sorl/thumbnail/kvstores/dynamodb_kvstore.py
+++ b/sorl/thumbnail/kvstores/dynamodb_kvstore.py
@@ -28,7 +28,7 @@ class KVStore(KVStoreBase):
             item = self.table.new_item()
             item['key'] = key
         item['value'] = value
-        item.save()
+        item.save(overwrite=True)
 
     def _delete_raw(self, *keys):
         [self.table.delete_item(key=k) for k in keys]

--- a/sorl/thumbnail/kvstores/dynamodb_kvstore.py
+++ b/sorl/thumbnail/kvstores/dynamodb_kvstore.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from boto.dynamodb2.table import Table
 import boto
-import json
 from sorl.thumbnail.kvstores.base import KVStoreBase
 from sorl.thumbnail.conf import settings
 
@@ -10,9 +9,11 @@ from sorl.thumbnail.conf import settings
 class KVStore(KVStoreBase):
     def __init__(self):
         super(KVStore, self).__init__()
-        conn = boto.dynamodb2.connect_to_region(settings.AWS_REGION_NAME,
-                aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        region = settings.AWS_REGION_NAME
+        access_key = settings.AWS_ACCESS_KEY_ID
+        secret = settings.AWS_SECRET_ACCESS_KEY
+        conn = boto.dynamodb2.connect_to_region(region, aws_access_key_id=access_key,
+                                                aws_secret_access_key=secret)
         self.table = Table(settings.THUMBNAIL_DYNAMODB_NAME, connection=conn)
 
     def _get_raw(self, key):

--- a/sorl/thumbnail/kvstores/dynamodb_kvstore.py
+++ b/sorl/thumbnail/kvstores/dynamodb_kvstore.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals
+
+from boto.dynamodb2.table import Table
+import boto
+import json
+from sorl.thumbnail.kvstores.base import KVStoreBase
+from sorl.thumbnail.conf import settings
+
+
+class KVStore(KVStoreBase):
+    def __init__(self):
+        super(KVStore, self).__init__()
+        conn = boto.dynamodb2.connect_to_region(settings.AWS_REGION_NAME,
+                aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        self.table = Table(settings.THUMBNAIL_DYNAMODB_NAME, connection=conn)
+
+    def _get_raw(self, key):
+        try:
+            return self.table.get_item(key=key)['value']
+        except boto.dynamodb2.exceptions.ItemNotFound:
+            pass
+
+    def _set_raw(self, key, value):
+        try:
+            item = self.table.get_item(key=key)
+        except boto.dynamodb2.exceptions.ItemNotFound:
+            item = self.table.new_item()
+            item['key'] = key
+        item['value'] = value
+        item.save()
+
+    def _delete_raw(self, *keys):
+        [self.table.delete_item(key=k) for k in keys]
+
+    def _find_keys_raw(self, prefix):
+        return [i['key'] for i in self.table.scan(key__beginswith=prefix)]

--- a/tests/settings/dynamodb.py
+++ b/tests/settings/dynamodb.py
@@ -1,0 +1,8 @@
+from .default import *
+
+
+THUMBNAIL_KVSTORE = 'sorl.thumbnail.kvstores.dynamodb_kvstore.KVStore'
+THUMBNAIL_DYNAMODB_NAME = 'test'
+AWS_REGION_NAME = 'eu-central-1'
+AWS_ACCESS_KEY_ID = 'use'
+AWS_SECRET_ACCESS_KEY = 'yours'

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ django_find_project = false
 skipsdist = True
 envlist =
     {py27}-django14-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm},
-    {py27,py34}-django{15,16,17,18}-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm}
+    {py27,py34}-django{15,16,17,18}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -20,6 +20,7 @@ deps =
     pytest-django
     Pillow
     redis: redis
+    dynamodb: boto
     pgmagick: pgmagick
     wand: wand
     django14: Django>=1.4,<1.5
@@ -34,6 +35,7 @@ setenv =
     imagemagick: DJANGO_SETTINGS_MODULE=tests.settings.imagemagick
     graphicsmagick: DJANGO_SETTINGS_MODULE=tests.settings.graphicsmagick
     redis: DJANGO_SETTINGS_MODULE=tests.settings.redis
+    dynamodb: DJANGO_SETTINGS_MODULE=tests.settings.dynamodb
     wand: DJANGO_SETTINGS_MODULE=tests.settings.wand
     pgmagick: DJANGO_SETTINGS_MODULE=tests.settings.pgmagick
     dbm: DJANGO_SETTINGS_MODULE=tests.settings.dbm


### PR DESCRIPTION
I am using this in production for some weeks now; but it is a pretty low traffic website. Testing the dynamodb backend needs some setup in the AWS console (most important synching the THUMBNAIL_DYNAMODB_NAME setting with an actual DynamoDB table + index you create on AWS).

I am not a dynamodb expert, so I am not sure if this has all the tweaks, but it works for me :-)