### PR TITLE
added support for relative protocol urls

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -86,6 +86,8 @@ class ImageFile(BaseImageFile):
             self.name = file_.name
         else:
             self.name = force_unicode(file_)
+        if self.name.startswith('//'):
+            self.name = 'http:' + self.name
 
         # figure out storage
         if storage is not None:


### PR DESCRIPTION
This allows to use sorl.thumbnail with urls like "//placekitten.com.s3.amazonaws.com/homepage-samples/200/286.jpg".