### PR TITLE
Use tempfile.mkstemp instead of NamedTemporaryFile for convert engine

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -63,8 +63,10 @@ class Engine(EngineBase):
             raise Exception(err)
 
         fp = os.fdopen(fd, 'rb')
-        thumbnail.write(fp.read())
-        fp.close()
+        try:
+            thumbnail.write(fp.read())
+        finally:
+            fp.close()
         os.remove(temp_path)
 
     def cleanup(self, image):
@@ -76,8 +78,10 @@ class Engine(EngineBase):
         """
         fd, temp_path = tempfile.mkstemp()
         fp = os.fdopen(fd, 'wb')
-        fp.write(source.read())
-        fp.close()
+        try:
+            fp.write(source.read())
+        finally:
+            fp.close()
         return {'source': temp_path, 'options': OrderedDict(), 'size': None}
 
     def get_image_size(self, image):
@@ -101,8 +105,10 @@ class Engine(EngineBase):
         fd, temp_path = tempfile.mkstemp()
 
         fp = os.fdopen(fd, 'wb')
-        fp.write(raw_data)
-        fp.close()
+        try:
+            fp.write(raw_data)
+        finally:
+            fp.close()
 
         args = settings.THUMBNAIL_IDENTIFY.split(' ')
         args.append(temp_path)

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -58,6 +58,8 @@ class Engine(EngineBase):
         out, err = p.communicate()
 
         if err:
+            os.close(fd)
+            os.remove(temp_path)
             raise Exception(err)
 
         fp = os.fdopen(fd, 'rb')


### PR DESCRIPTION
With Python stdlib tempfile.NamedTemporaryFile or Django
django.core.files.temp.NamedTemporaryFile it is not possible to open the
temporary file in another process from within a with
NamedTemporaryFile(...) as fp: block. Also Django's implementation lacks
the support for several arguments like delete on Windows. This
combination of characteristics of the two NamedTemporaryFile
implementations makes the convert engine unusable under Windows at the
moment. By using tempfile.mkstemp it is possible to open the file in
another subprocess even under Windows and the issues are resolved.

This would also resolve #419 and is somehow a resurection of the effort in #358 because it turned out that #392 was not enough to fix the convert engine under Windows.