### PR TITLE
Django19 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,12 @@ env:
   - TOX_ENV=py34-django18-redis
   - TOX_ENV=py34-django18-wand
   - TOX_ENV=py34-django18-dbm
+  - TOX_ENV=py34-django19-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
+  - TOX_ENV=py34-django19-imagemagick APT=imagemagick
+  - TOX_ENV=py34-django19-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py34-django19-redis
+  - TOX_ENV=py34-django19-wand
+  - TOX_ENV=py34-django19-dbm
 
 before_install:
   - sudo apt-get update -qq

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Thumbnails for Django.
 Features at a glance
 ====================
 
-- Support for Django 1.4, 1.5, 1.6, 1.7 and 1.8
-- Python 3 support (for Django 1.5, 1.6, 1.7, 1.8)
+- Support for Django 1.4, 1.5, 1.6, 1.7, 1.8, 1.9
+- Python 3 support (for Django 1.5, 1.6, 1.7, 1.8, 1.9)
 - Storage support
 - Pluggable Engine support for `Pillow`_, `ImageMagick`_, `PIL`_, `Wand`_ and `pgmagick`_
 - Pluggable Key Value Store support (cached db, redis)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -19,6 +19,10 @@ Django versions, we provide an easy way to test locally across all of them.
 We use `Vagrant`_ for simple interaction with virtual machines and
 `tox`_ for managing python virtual environments.
 
+Some dependencies like pgmagick takes a lot of time to compiling. To speed up your
+vagrant box you can edit `Vagrant file`_ with mem and cpu or simply install `vagrant-faster`_.
+The resulting .tox folder containing all virtualenvs requires ~
+
 * `Install Vagrant`_
 * ``cd`` in your source directory
 * Run ``vagrant up`` to prepare VM. It will download Ubuntu image and install all necessary dependencies.
@@ -27,9 +31,9 @@ We use `Vagrant`_ for simple interaction with virtual machines and
 
 To run only tests against only one configuration use ``-e`` option::
 
-    tox -e py33-1.6-pil
+    tox -e py34-django16-pil
 
-Py33 stands for python version, 1.6 is Django version and the latter is image library.
+Py34 stands for python version, 1.6 is Django version and the latter is image library.
 For full list of tox environments, see ``tox.ini``
 
 You can get away without using Vagrant if you install all packages locally yourself,
@@ -39,6 +43,8 @@ however, this is not recommended.
 .. _Vagrant: http://www.vagrantup.com/
 .. _tox: https://testrun.org/tox/latest/
 .. _Install Vagrant: http://docs.vagrantup.com/v2/installation/index.html
+.. _Vagrant file: https://docs.vagrantup.com/v2/virtualbox/configuration.html
+.. _vagrant-faster: https://github.com/rdsubhas/vagrant-faster
 
 Sending pull requests
 =====================

--- a/tests/settings/default.py
+++ b/tests/settings/default.py
@@ -27,6 +27,8 @@ MEDIA_ROOT = pjoin(PROJ_ROOT, 'media')
 MEDIA_URL = '/media/'
 ROOT_URLCONF = 'tests.thumbnail_tests.urls'
 INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
     'sorl.thumbnail',
     'tests.thumbnail_tests',
 )

--- a/tests/thumbnail_tests/compat.py
+++ b/tests/thumbnail_tests/compat.py
@@ -1,14 +1,9 @@
-import sys
 import platform
 
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
-
-
-if PY3:
+try:
+    import unittest2 as unittest
+except ImportError:
     import unittest
-else:
-    from django.utils import unittest
 
 
 def is_osx():

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ django_find_project = false
 skipsdist = True
 envlist =
     {py27}-django14-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm},
-    {py27,py34}-django{15,16,17,18}-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm}
+    {py27,py34}-django{15,16,17,18,19}-{pil,imagemagick,graphicsmagick,redis,wand,pgmagick,dbm}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -27,6 +27,7 @@ deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
 
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 apt-get update
-apt-get install -qq python-software-properties python-pip
+apt-get install -qq git python-software-properties python-pip
 apt-get install -qq libjpeg62 libjpeg62-dev zlib1g-dev imagemagick graphicsmagick redis-server
 apt-get install -qq libmagickwand-dev libgraphicsmagick++-dev libboost-python-dev libboost-thread-dev
 
 add-apt-repository -y ppa:fkrull/deadsnakes
 apt-get update
-apt-get install -qq python2.7 python2.7-dev python3.3 python3.3-dev
+apt-get install -qq python2.7 python2.7-dev python3.4 python3.4-dev
 
 pip install tox
+
+# Fix locale to allow saving unicoded filenames
+echo 'LANG=en_US.UTF-8' > /etc/default/locale
 
 # Start in project dir by default
 echo "\n\ncd /vagrant" >> /home/vagrant/.bashrc


### PR DESCRIPTION
as requested in #430...

Fixes for Django1.9 support:
- `django.test.Client.get()` requires `django.contrib.auth` and `django.contrib.contenttypes` to load `Permission` model (see 20fdc3b)
- `from django.utils import unittest` is drop out, i "cloned" the code into `tests.thumbnail_tests.compat.py` (see d4b6c96)
- Updated README.rst (see f7ebc84)

Testing:
- The Django 1.8 series is the last to support Python 3.2 and 3.3, so i upgraded `tox.ini`, `vagrant.sh`and `.travis` (see d4b6c96 and cea55cc)

Other:
- Added a fix into `vagrant.sh` to correctly provision locale variables (unicoded filenames raises exception in tests, see d4b6c96)
- Tips to improve testing speed with vagrant into `docs/contributing.rst` (see 87fee03)
