### PR TITLE
bugfix for unicode filenames

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -193,11 +193,8 @@ class UrlStorage(Storage):
         url = encode(url, charset, 'ignore')
         scheme, netloc, path, qs, anchor = urlsplit(url)
 
-        # Encode to utf8 to prevent urllib KeyError
-        path = encode(path, charset, 'ignore')
-
-        path = quote(path, '/%')
-        qs = quote_plus(qs, ':&%=')
+        path = quote(path, b'/%')
+        qs = quote_plus(qs, b':&%=')
 
         return urlparse.urlunsplit((scheme, netloc, path, qs, anchor))
 


### PR DESCRIPTION
A patch for handling non-ascii characters in filenames. Avoids double encoding to utf8, fixes accompanying UnicodeDecodeError.