### PR TITLE
Close #263. Enable GIF support

### DIFF
--- a/sorl/thumbnail/admin/compat.py
+++ b/sorl/thumbnail/admin/compat.py
@@ -35,6 +35,8 @@ class AdminImageWidget(forms.FileInput):
                 aux_ext = str(value).split('.')
                 if aux_ext[len(aux_ext)-1].lower() == 'png':
                     ext = 'PNG'
+                if aux_ext[len(aux_ext)-1].lower() == 'gif':
+                    ext = 'GIF'
             except:
                 pass
             try:

--- a/sorl/thumbnail/admin/current.py
+++ b/sorl/thumbnail/admin/current.py
@@ -30,6 +30,8 @@ class AdminImageWidget(forms.ClearableFileInput):
                 aux_ext = str(value).split('.')
                 if aux_ext[len(aux_ext) - 1].lower() == 'png':
                     ext = 'PNG'
+                elif aux_ext[len(aux_ext) - 1].lower() == 'gif':
+                    ext = 'GIF'
             except:
                 pass
             try:

--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 EXTENSIONS = {
     'JPEG': 'jpg',
     'PNG': 'png',
+    'GIF': 'gif',
 }
 
 
@@ -54,6 +55,8 @@ class ThumbnailBackend(object):
             return 'JPEG'
         elif file_extension == '.png':
             return 'PNG'
+        elif file_extension == '.gif':
+            return 'GIF'
         else:
             from django.conf import settings
 

--- a/sorl/thumbnail/conf/defaults.py
+++ b/sorl/thumbnail/conf/defaults.py
@@ -58,7 +58,7 @@ THUMBNAIL_KEY_PREFIX = 'sorl-thumbnail'
 # Thumbnail filename prefix
 THUMBNAIL_PREFIX = 'cache/'
 
-# Image format, common formats are: JPEG, PNG
+# Image format, common formats are: JPEG, PNG, GIF
 # Make sure the backend can handle the format you specify
 THUMBNAIL_FORMAT = 'JPEG'
 

--- a/tests/thumbnail_tests/test_backends.py
+++ b/tests/thumbnail_tests/test_backends.py
@@ -59,6 +59,7 @@ class PreserveFormatTest(TestCase):
         self.assertEqual(self.backend._get_format(FakeFile('foo.jpg')), 'JPEG')
         self.assertEqual(self.backend._get_format(FakeFile('foo.jpeg')), 'JPEG')
         self.assertEqual(self.backend._get_format(FakeFile('foo.png')), 'PNG')
+        self.assertEqual(self.backend._get_format(FakeFile('foo.gif')), 'GIF')
 
     def test_double_extension(self):
         self.assertEqual(self.backend._get_format(FakeFile('foo.ext.jpg')), 'JPEG')


### PR DESCRIPTION
Look like this is the only change required to enable GIF support.

The only caveat is that only the first frame of an animate gif will rendered. IE the animation will not be preserved.