### PR TITLE
Update installation instructions for new versions of Django.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,5 +21,6 @@ Setup
 3. If you are using the cached database key value store you need to sync the
    database::
 
-    python manage.py syncdb
+    python manage.py makemigrations thumbnail
+    python manage.py migrate
 


### PR DESCRIPTION
`syncdb` was deprecated in Django 1.7 and `makemigrations` and `migrate` should be used instead.