### PR TITLE
Fixed 'P' mode pngs transparency issue

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -100,7 +100,7 @@ class Engine(EngineBase):
                 newimage = image.convert('RGBA')
                 transparency = image.info.get('transparency')
                 if transparency is not None:
-                    mask = Image.new('L', image.size, color=transparency)
+                    mask = image.convert('RGBA').split()[-1]
                     newimage.putalpha(mask)
                 return newimage
             return image.convert('RGB')


### PR DESCRIPTION
'P' mode PNG images were raising an error showing "new style getargs format but argument is not a tuple", this has been avoided by extracting the alpha mask from the image instead of relying on its transparency info.