### PR TITLE
add webp format to image extensions list

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -18,6 +18,7 @@ EXTENSIONS = {
     'JPEG': 'jpg',
     'PNG': 'png',
     'GIF': 'gif',
+    'WEBP': 'webp',
 }
 
 
@@ -57,6 +58,8 @@ class ThumbnailBackend(object):
             return 'PNG'
         elif file_extension == '.gif':
             return 'GIF'
+        elif file_extension == '.webp':
+            return 'WEBP'
         else:
             from django.conf import settings
 


### PR DESCRIPTION
Adds the webp extension to the `thumbnails.base.EXTENSIONS` list for backends that support it, as mentioned here #267.