### PR TITLE
Don’t silently ignore missing file_ argument

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -74,7 +74,13 @@ class ThumbnailBackend(object):
         """
         logger.debug('Getting thumbnail for file [%s] at [%s]', file_, geometry_string)
 
-        source = ImageFile(file_)
+        if file_:
+            source = ImageFile(file_)
+        else:
+            if settings.THUMBNAIL_DUMMY:
+                return DummyImageFile(geometry_string)
+            else:            
+                raise ValueError('missing file_ argument in get_thumbnail()')
 
         # preserve image filetype
         if settings.THUMBNAIL_PRESERVE_FORMAT:

--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -74,12 +74,7 @@ class ThumbnailBackend(object):
         """
         logger.debug('Getting thumbnail for file [%s] at [%s]', file_, geometry_string)
 
-        if file_:
-            source = ImageFile(file_)
-        elif settings.THUMBNAIL_DUMMY:
-            return DummyImageFile(geometry_string)
-        else:
-            return None
+        source = ImageFile(file_)
 
         # preserve image filetype
         if settings.THUMBNAIL_PRESERVE_FORMAT:


### PR DESCRIPTION
Passing something that isn't an image to the get_thumbnail function indicates an error somewhere else in the code, so it shouldn't be silently ignored