### PR TITLE
Fix delete_all_thumbnails command

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -228,7 +228,7 @@ class UrlStorage(Storage):
 
 def delete_all_thumbnails():
     storage = default.storage
-    path = os.path.join(storage.location, settings.THUMBNAIL_PREFIX)
+    path = settings.THUMBNAIL_PREFIX
 
     def walk(path):
         dirs, files = storage.listdir(path)


### PR DESCRIPTION
Storage paths are always relative to storage location => we should not prepend this manually